### PR TITLE
templates: html5 location issue

### DIFF
--- a/invenio_search_ui/static/templates/invenio_search_ui/marc21/default.html
+++ b/invenio_search_ui/static/templates/invenio_search_ui/marc21/default.html
@@ -1,6 +1,6 @@
 <ul>
   <li ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
-    <h4><a ng-href="{{ record.links.self }}">{{ record.metadata.title_statement.title }}</a></h4>
+    <h4><a target="_self" ng-href="/record/{{ record._id }}">{{ record.metadata.title_statement.title }}</a></h4>
     <p>{{ record.metadata.summary[0].summary }}</p>
     <div class="text-right">
       <ul class="list-inline">


### PR DESCRIPTION
* FIX Fixes `window.location` when changing url. The issue was due to
 `html5mode` option in angular, which changes the behavior of
 `window.location`.

Signed-off-by: Harris Tzovanakis <me@drjova.com>