### PR TITLE
views: extra params template variable

### DIFF
--- a/invenio_search_ui/templates/invenio_search_ui/search.html
+++ b/invenio_search_ui/templates/invenio_search_ui/search.html
@@ -37,6 +37,7 @@
 <div id="invenio-search">
   <invenio-search
    search-endpoint="{{ config.SEARCH_UI_SEARCH_API }}"
+   search-extra-params='{% if search_extra_params %}{{search_extra_params|tojson}}{% endif %}'
    search-hidden-params='{% if search_hidden_params %}{{search_hidden_params|tojson}}{% endif %}'
    search-headers='{"Accept": "{{ config.SEARCH_UI_SEARCH_MIMETYPE|default('application/json')}}"}'
   >


### PR DESCRIPTION
* Adds the `search_extra_params` template variable to the
  `invenio-search-js` initializer.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>