### PR TITLE
pagination: align to center

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
@@ -1,6 +1,7 @@
 /*
  * This file is part of Invenio.
  * Copyright (C) 2020 CERN.
+ * Copyright (C) 2021 Graz University of Technology.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
@@ -33,6 +34,7 @@ export const Results = ({ currentResultsState = {} }) => {
         id={"SearchApp.results"}
         {...{
           sortOptions,
+          paginationOptions,
           currentResultsState,
           layoutOptions,
         }}
@@ -52,9 +54,15 @@ export const Results = ({ currentResultsState = {} }) => {
           <Grid.Row verticalAlign="middle">
             <Grid.Column width={4}></Grid.Column>
             <Grid.Column width={8} textAlign="center">
-              <Pagination />
+              <Pagination
+                options={{
+                  size: "mini",
+                  showFirst: false,
+                  showLast: false,
+                }}
+              />
             </Grid.Column>
-            <Grid.Column width={4} textAlign="right">
+            <Grid.Column textAlign="right" width={4}>
               <ResultsPerPage
                 values={paginationOptions.resultsPerPage}
                 label={(cmp) => <> {cmp} results per page</>}


### PR DESCRIPTION
Regarding space between pagination and footer i don't see any problems, at least not with invenioRDM footer.

closes inveniosoftware/invenio-app-rdm#526

*screenshot*
![pagination](https://user-images.githubusercontent.com/44528277/107032058-7a15fb80-67b3-11eb-9a1c-c8292dbcb59e.png)
