### PR TITLE
webpack: bump axios for security

### DIFF
--- a/invenio_search_ui/version.py
+++ b/invenio_search_ui/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/invenio_search_ui/webpack.py
+++ b/invenio_search_ui/webpack.py
@@ -29,7 +29,7 @@ search_ui = WebpackThemeBundle(
                 "invenio_search_ui_app": "./js/invenio_search_ui/app.js",
             },
             dependencies={
-                "axios": "^0.19.0",
+                "axios": "^0.21.1",
                 "lodash": "^4.17.15",
                 "qs": "^6.8.0",
                 "react": "^16.13.0",


### PR DESCRIPTION
- part of closing https://github.com/inveniosoftware/invenio-app-rdm/issues/956
- js-dependencies: bump axios to 0.21.1
- release: v2.0.3
