### PR TITLE
theme: allow app namespacing

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
@@ -24,14 +24,13 @@ import { SearchConfigurationContext } from "./context";
 
 export const Results = ({ currentResultsState = {} }) => {
   const { total } = currentResultsState.data;
-  const { sortOptions, layoutOptions, paginationOptions } = useContext(
-    SearchConfigurationContext
-  );
+  const { sortOptions, layoutOptions, paginationOptions, buildUID } =
+    useContext(SearchConfigurationContext);
   const multipleLayouts = layoutOptions.listView && layoutOptions.gridView;
   return (
     (total || null) && (
       <Overridable
-        id={"SearchApp.results"}
+        id={buildUID("SearchApp.results")}
         {...{
           sortOptions,
           paginationOptions,
@@ -82,12 +81,13 @@ export const ResultOptions = ({ currentResultsState = {} }) => {
     paginationOptions,
     sortOrderDisabled,
     layoutOptions,
+    buildUID,
   } = useContext(SearchConfigurationContext);
   const multipleLayouts = layoutOptions.listView && layoutOptions.gridView;
   return (
     (total || null) && (
       <Overridable
-        id={"SearchApp.resultOptions"}
+        id={buildUID("SearchApp.resultOptions")}
         {...{
           currentResultsState,
           sortOptions,
@@ -103,7 +103,10 @@ export const ResultOptions = ({ currentResultsState = {} }) => {
             </Grid.Column>
             <Grid.Column width={8} textAlign="right">
               {sortOptions && (
-                <Overridable id={"SearchApp.sort"} options={sortOptions}>
+                <Overridable
+                  id={buildUID("SearchApp.sort")}
+                  options={sortOptions}
+                >
                   <Sort
                     sortOrderDisabled={sortOrderDisabled || false}
                     values={sortOptions}

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
@@ -7,7 +7,7 @@
  */
 
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext } from "react";
 import Overridable, {
   OverridableContext,
   overrideStore,
@@ -20,6 +20,7 @@ import {
   ReactSearchKit,
   ResultsLoader,
   withState,
+  buildUID,
 } from "react-searchkit";
 import { Container, Grid } from "semantic-ui-react";
 import { Results, ResultOptions } from "./Results";
@@ -30,8 +31,9 @@ const OnResults = withState(Results);
 const ResultOptionsWithState = withState(ResultOptions);
 
 export const SearchAppFacets = ({ aggs }) => {
+  const { buildUID } = useContext(SearchConfigurationContext);
   return (
-    <Overridable id={"SearchApp.facets"} aggs={aggs}>
+    <Overridable id={buildUID("SearchApp.facets")} aggs={aggs}>
       <>
         {aggs.map((agg) => (
           <BucketAggregation key={agg.title} title={agg.title} agg={agg.agg} />
@@ -42,8 +44,12 @@ export const SearchAppFacets = ({ aggs }) => {
 };
 
 export const SearchAppResultsPane = ({ layoutOptions }) => {
+  const { buildUID } = useContext(SearchConfigurationContext);
   return (
-    <Overridable id={"SearchApp.resultsPane"} layoutOptions={layoutOptions}>
+    <Overridable
+      id={buildUID("SearchApp.resultsPane")}
+      layoutOptions={layoutOptions}
+    >
       <ResultsLoader>
         <EmptyResults />
         <Error />
@@ -55,9 +61,14 @@ export const SearchAppResultsPane = ({ layoutOptions }) => {
 
 export const SearchApp = ({ config, appName }) => {
   const searchApi = new InvenioSearchApi(config.searchApi);
+  const context = {
+    appName,
+    buildUID: (element) => buildUID(element, "", appName),
+    ...config,
+  };
   return (
     <OverridableContext.Provider value={overrideStore.getAll()}>
-      <SearchConfigurationContext.Provider value={config}>
+      <SearchConfigurationContext.Provider value={context}>
         <ReactSearchKit
           searchApi={searchApi}
           appName={appName}
@@ -66,14 +77,21 @@ export const SearchApp = ({ config, appName }) => {
             config.defaultSortingOnEmptyQueryString
           }
         >
-          <Overridable id={"SearchApp.layout"} config={config}>
+          <Overridable
+            id={buildUID("SearchApp.layout", "", appName)}
+            config={config}
+          >
             <Container>
-              <Overridable id={"SearchApp.searchbarContainer"}>
+              <Overridable
+                id={buildUID("SearchApp.searchbarContainer", "", appName)}
+              >
                 <Grid relaxed padded>
                   <Grid.Row>
                     <Grid.Column width={4} />
                     <Grid.Column width={12}>
-                      <Overridable id={"SearchApp.searchbar"}>
+                      <Overridable
+                        id={buildUID("SearchApp.searchbar", "", appName)}
+                      >
                         <SearchBar />
                       </Overridable>
                     </Grid.Column>

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/index.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/index.js
@@ -9,7 +9,4 @@
 import defaultComponents from "./defaultComponents";
 import { createSearchAppInit } from "./util";
 
-export {
-  defaultComponents,
-  createSearchAppInit,
-};
+export { defaultComponents, createSearchAppInit };

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/util.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/util.js
@@ -12,17 +12,36 @@ import { SearchApp } from "./components";
 import { loadComponents } from "@js/invenio_theme/templates";
 import _camelCase from "lodash/camelCase";
 
+/**
+ * Initialize React search application.
+ * @function
+ * @param {object} defaultComponents - default components to load if no overriden have been registered.
+ * @param {boolean} autoInit - if true then the application is getting registered to the DOM.
+ * @param {string} autoInitDataAttr - data attribute to register application to DOM and retrieve config.
+ * @param {object} multi - enable multiple search application support.
+ *    If true, the application is namespaced using `config.appId`. That allows
+ *    users to override each application's components using `appId` as a prefix.
+ * @returns {object} frontend compatible record object
+ */
 export function createSearchAppInit(
   defaultComponents,
   autoInit = true,
-  autoInitDataAttr = "invenio-search-config"
+  autoInitDataAttr = "invenio-search-config",
+  multi = false
 ) {
   const initSearchApp = (rootElement) => {
-    const config = JSON.parse(
+    const { appId, ...config } = JSON.parse(
       rootElement.dataset[_camelCase(autoInitDataAttr)]
     );
-    loadComponents(config.appId, defaultComponents).then((res) => {
-      ReactDOM.render(<SearchApp config={config} />, rootElement);
+    loadComponents(appId, defaultComponents).then((res) => {
+      ReactDOM.render(
+        <SearchApp
+          config={config}
+          // Use appName to namespace application components when overriding
+          {...(multi && { appName: appId })}
+        />,
+        rootElement
+      );
     });
   };
 


### PR DESCRIPTION
requires https://github.com/inveniosoftware/react-searchkit/pull/213
closes #124 

* This PR enables multiple search applications on the same page via the `createSearchAppInit` function. 
* If `allowMultipleApps` is passed to the function then the provided `appId` will be used to namespace the components available to be overriden. For example:

```javascript

// index.js
createSearchAppInit({'myapp.ResultsList.element': MyComponent}, true, "invenio-search-config", true);

// search.html
<div data-invenio-search-config='{{
  search_app_helpers.invenio_records_rest.generate(
    dict(
      endpoint_id="recid",
      app_id="myapp"
    )
  ) | tojson(indent=2) }}'></div>
{%- endblock page_body -%}

```