### PR TITLE
search app: add responsive layout

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
@@ -22,10 +22,13 @@ import {
   withState,
   buildUID,
 } from "react-searchkit";
-import { Container, Grid } from "semantic-ui-react";
+import { GridResponsiveSidebarColumn } from "react-invenio-forms";
+import { Container, Grid, Button } from "semantic-ui-react";
 import { Results, ResultOptions } from "./Results";
 import { SearchBar } from "./SearchBar";
 import { SearchConfigurationContext } from "./context";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+
 
 const OnResults = withState(Results);
 const ResultOptionsWithState = withState(ResultOptions);
@@ -60,6 +63,7 @@ export const SearchAppResultsPane = ({ layoutOptions }) => {
 };
 
 export const SearchApp = ({ config, appName }) => {
+  const [sidebarVisible, setSidebarVisible] = React.useState(false);
   const searchApi = new InvenioSearchApi(config.searchApi);
   const context = {
     appName,
@@ -87,8 +91,7 @@ export const SearchApp = ({ config, appName }) => {
               >
                 <Grid relaxed padded>
                   <Grid.Row>
-                    <Grid.Column width={4} />
-                    <Grid.Column width={12}>
+                    <Grid.Column width={12} floated="right">
                       <Overridable
                         id={buildUID("SearchApp.searchbar", "", appName)}
                       >
@@ -98,25 +101,46 @@ export const SearchApp = ({ config, appName }) => {
                   </Grid.Row>
                 </Grid>
               </Overridable>
+
               <Grid relaxed>
                 <Grid.Row
                   textAlign="right"
                   columns={2}
                   className="result-options rel-mt-2"
                 >
-                  <Grid.Column width={4} />
-                  <Grid.Column width={12}>
+                  <Grid.Column
+                    only="mobile tablet"
+                    mobile={2}
+                    tablet={1}
+                    textAlign="center"
+                    verticalAlign="middle"
+                  >
+                    <Button
+                      basic
+                      icon="sliders"
+                      onClick={() => setSidebarVisible(true)}
+                      aria-label={i18next.t("Filter results")}
+                    />
+                  </Grid.Column>
+
+                  <Grid.Column mobile={14} tablet={15} computer={12} floated="right">
                     <ResultOptionsWithState
                       sortOptions={config.sortOptions}
                       layoutOptions={config.layoutOptions}
                     />
                   </Grid.Column>
                 </Grid.Row>
+
                 <Grid.Row columns={2}>
-                  <Grid.Column width={4}>
-                    <SearchAppFacets aggs={config.aggs} />
-                  </Grid.Column>
-                  <Grid.Column width={12}>
+                  <GridResponsiveSidebarColumn
+                    width={4}
+                    open={sidebarVisible}
+                    onHideClick={() => setSidebarVisible(false)}
+                    children={
+                      <SearchAppFacets aggs={config.aggs} />
+                    }
+                  />
+                  <Grid.Column mobile={16} tablet={16} computer={12}>
                     <SearchAppResultsPane
                       layoutOptions={config.layoutOptions}
                     />

--- a/invenio_search_ui/webpack.py
+++ b/invenio_search_ui/webpack.py
@@ -41,6 +41,7 @@ search_ui = WebpackThemeBundle(
                 "redux": "^4.0.0",
                 "redux-thunk": "^2.3.0",
                 "react-searchkit": "^2.0.0",
+                "react-invenio-forms": "^0.10.0",
                 "semantic-ui-css": "^2.4.0",
                 "semantic-ui-react": "^2.1.0",
             },


### PR DESCRIPTION
**Needs [react-invenio-forms PR 118](https://github.com/inveniosoftware/react-invenio-forms/pull/118)**

Solves the responsibility issues for the search results page of [#1360](https://github.com/inveniosoftware/invenio-app-rdm/issues/1360). The My Dashboard issue must be solved in `invenio-app-rdm`.

- Changed the column width of the main content to be full grid-width for mobile and tablet.
- Moved the facet filter to a slide-in sidebar triggered by a filter button for mobile and tablet.
- The desktop version remains the same as before.

The sidebar closes when clicking the close-button or by clicking outside the sidebar.

Accessibility was tested with axe DevTools and VoiceOver.

## Screenshots

### Tablet
__Filter closed__
<img width="885" alt="Screenshot 2022-03-10 at 10 11 48" src="https://user-images.githubusercontent.com/21052053/157630155-3284467d-b693-42e9-8a9b-928f94052089.png">

__Filter open__
<img width="884" alt="Screenshot 2022-03-10 at 10 11 41" src="https://user-images.githubusercontent.com/21052053/157630283-cda6ae8d-c58b-4cfc-a730-32e5ef6a280b.png">

### Mobile
__Filter closed__
<img width="469" alt="Screenshot 2022-03-10 at 10 12 08" src="https://user-images.githubusercontent.com/21052053/157630293-38709b54-7afb-47de-a504-f165d7a3bdce.png">


__Filter open__
<img width="468" alt="Screenshot 2022-03-10 at 10 12 16" src="https://user-images.githubusercontent.com/21052053/157630327-fae829d7-87d4-4322-b70e-6321599b5adc.png">

