### PR TITLE
release: v2.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 2.1.0 (released 2022-04-05)
+
+- Upgrade react-searchkit version to v2.0.0
+
 Version 2.0.10 (released 2022-04-05)
 
 - Relax min Python version to 3.6.

--- a/invenio_search_ui/__init__.py
+++ b/invenio_search_ui/__init__.py
@@ -327,6 +327,6 @@ of the record in a list by using the ``ng-repeat`` attribute and the
 
 from .ext import InvenioSearchUI
 
-__version__ = "2.0.10"
+__version__ = "2.1.0"
 
 __all__ = ('__version__', 'InvenioSearchUI')

--- a/invenio_search_ui/webpack.py
+++ b/invenio_search_ui/webpack.py
@@ -40,7 +40,7 @@ search_ui = WebpackThemeBundle(
                 "react-redux": "^7.2.0",
                 "redux": "^4.0.0",
                 "redux-thunk": "^2.3.0",
-                "react-searchkit": "^1.0.0",
+                "react-searchkit": "^2.0.0",
                 "semantic-ui-css": "^2.4.0",
                 "semantic-ui-react": "^2.1.0",
             },


### PR DESCRIPTION
`react-searchkit` `v2.0.0` introduces a few breaking changes, and we need to bump `invenio-search-ui`.
We need to decide what to do with `Invenio` version before releasing this version, given that the [current version](https://github.com/inveniosoftware/invenio/blob/2ce61fb8e820979264f1ef4131e544870b5ad09b/setup.py#L50) will not install this version.

