### PR TITLE
results: add label to sort dropdown

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
@@ -94,6 +94,11 @@ export const ResultOptions = ({ currentResultsState = {} }) => {
                     sortOrderDisabled={sortOrderDisabled || false}
                     values={sortOptions}
                     ariaLabel={i18next.t("Sort")}
+                    label={(cmp) => (
+                      <>
+                        <label className="mr-10">{i18next.t("Sort by")}</label>{cmp}
+                      </>
+                    )}
                   />
                 </Overridable>
               )}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1697
- Adds missing label to sort dropdown on main search results page

## Screenshot
![Screenshot 2022-07-08 at 15 39 17](https://user-images.githubusercontent.com/21052053/178003296-5bb3ffca-2411-49ed-907c-0ba27ddc938f.png)

