### PR TITLE
fix MultipleOptionsSearchBarCmp click option is missing the context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 Changes
 =======
 
+Version 2.1.6 (released 2022-08-03)
+
+- multi-opion searchbar: fix options fixed to option 1
 
 Version 2.1.5 (released 2022-08-02)
 

--- a/invenio_search_ui/__init__.py
+++ b/invenio_search_ui/__init__.py
@@ -327,6 +327,6 @@ of the record in a list by using the ``ng-repeat`` attribute and the
 
 from .ext import InvenioSearchUI
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"
 
 __all__ = ("__version__", "InvenioSearchUI")

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/MultipleOptionsSearchBar.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/MultipleOptionsSearchBar.js
@@ -107,10 +107,11 @@ MultipleOptionsSearchBar.defaultProps = {
 export class MultipleOptionsSearchBarCmp extends Component {
   /** Multiple options searchbar to be wrapped with RSK context
    */
-  onBtnSearchClick = () => {
+  onBtnSearchClick = (e, { result }) => {
     const { queryString, updateQueryState, currentQueryState } = this.props;
-    const { options, defaultOption } = this.props;
-    let destinationURL = options[0]?.value || defaultOption.value;
+    const { defaultOption } = this.props;
+    const { value: url } = result;
+    const destinationURL = url || defaultOption.value;
 
     if (window.location.pathname === destinationURL) {
       updateQueryState({ ...currentQueryState, queryString });
@@ -169,11 +170,11 @@ MultipleOptionsSearchBarCmp.propTypes = {
 
 MultipleOptionsSearchBarCmp.defaultProps = {
   placeholder: i18next.t("Search records..."),
-  // defaultOption: {
-  //   key: "records",
-  //   text: i18next.t("All records"),
-  //   value: "/search",
-  // },
+  defaultOption: {
+    key: "records",
+    text: i18next.t("All records"),
+    value: "/search",
+  },
 };
 
 export const MultipleOptionsSearchBarRSK = withState(


### PR DESCRIPTION
fix MultipleOptionsSearchBarCmp click option is missing the context
    
 clicking on a option leads to search always on the first possible
 option. now the context of the click is given to the handle function,
 similar to the click handle function in the MultipleOptionsSearchBar
 component. The context (in this function called "result") gives then
 the correct destinationURL.
    
 NOTE: bring back the commented default option
