### PR TITLE
search app: make list full width if no facets available

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
@@ -28,7 +28,7 @@ export const Results = ({ currentResultsState = {} }) => {
     useContext(SearchConfigurationContext);
   const multipleLayouts = layoutOptions.listView && layoutOptions.gridView;
   return (
-    (total || null) && (
+    (total) && (
       <Overridable
         id={buildUID("SearchApp.results")}
         {...{

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchAppFacets.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchAppFacets.js
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2022 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import React from "react";
+import {
+  BucketAggregation,
+} from "react-searchkit";
+import Overridable, {
+} from "react-overridable";
+
+export const SearchAppFacets = ({ aggs, buildUID, appName }) => {
+
+  return (
+    <Overridable id={buildUID("SearchApp.facets", "", appName)} aggs={aggs}>
+      <>
+        {aggs.map((agg) => (
+          <BucketAggregation key={agg.title} title={agg.title} agg={agg.agg} />
+        ))}
+      </>
+    </Overridable>
+  );
+};
+

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchAppResultsPane.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchAppResultsPane.js
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2022 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+import { Results } from "./Results";
+import React from "react";
+import {
+  EmptyResults,
+  Error,
+  ResultsLoader,
+  withState,
+} from "react-searchkit";
+
+import Overridable, {
+} from "react-overridable";
+
+
+const OnResults = withState(Results);
+
+export const SearchAppResultsPane = ({ layoutOptions, buildUID, appName }) => {
+
+  return (
+    <Overridable
+      id={buildUID("SearchApp.resultsPane", "", appName)}
+      layoutOptions={layoutOptions}
+    >
+      <ResultsLoader>
+        <EmptyResults />
+        <Error />
+        <OnResults />
+      </ResultsLoader>
+    </Overridable>
+  );
+};

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchBar.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchBar.js
@@ -10,14 +10,19 @@ import React from "react";
 import { SearchBar as ReactSearchKitSearchBar } from "react-searchkit";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
+import Overridable from "react-overridable";
 
-export const SearchBar = ({ elementId }) => {
+export const SearchBar = ({ elementId, buildUID, appName }) => {
   const domElement = document.getElementById(elementId);
   if (domElement) {
     domElement.innerHTML = "";
     return ReactDOM.createPortal(<ReactSearchKitSearchBar />, domElement);
   }
-  return <ReactSearchKitSearchBar />;
+  return (
+    <Overridable id={buildUID("SearchApp.searchbar", "", appName)}>
+      <ReactSearchKitSearchBar />
+    </Overridable>
+  );
 };
 
 SearchBar.propTypes = {

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchDropdowns.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchDropdowns.js
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2022 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import React, { Component } from "react";
+import { Dropdown, Icon } from "semantic-ui-react";
+import PropTypes from "prop-types";
+
+export class DropdownSort extends Component {
+  render() {
+    const {
+      options,
+      currentSortBy,
+      onValueChange,
+      ariaLabel,
+      selectOnNavigation,
+      ...uiProps
+    } = this.props;
+
+    const optionsWithDisabled = options.map((option) => {
+      const disabled = currentSortBy === option.sortBy;
+      return {
+        key: option.value,
+        text: option.text,
+        value: option.value,
+        disabled: disabled,
+      };
+    });
+    return (
+      <Dropdown
+        icon="sort"
+        button
+        labeled
+        item
+        trigger={
+          <span className='capitalize'>
+            {currentSortBy}
+            <Icon name='dropdown'/>
+          </span>
+        }
+        options={optionsWithDisabled}
+        value={currentSortBy}
+        onChange={(_, { value }) => onValueChange(value)}
+        aria-label={ariaLabel}
+        selectOnNavigation={selectOnNavigation}
+        selectOnBlur={false}
+        size="large"
+        className="icon fluid-responsive"
+      />
+    );
+  }
+}
+
+DropdownSort.propTypes = {
+  options: PropTypes.array.isRequired,
+  currentSortBy: PropTypes.string,
+  overridableId: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  selectOnNavigation: PropTypes.bool,
+  onValueChange: PropTypes.func.isRequired,
+};
+
+export class DropdownFilter extends Component {
+  onChangeFilter = (e, data) => {
+    const { updateQueryState, currentQueryState } = this.props;
+    currentQueryState.filters.push(JSON.parse(data.value));
+    updateQueryState(currentQueryState);
+  };
+
+  render() {
+    const {
+      filterKey,
+      filterValues,
+      filterLabel,
+      currentQueryState,
+      updateQueryState,
+      loading,
+      ...uiProps
+    } = this.props;
+    const options = filterValues.map((filterValue) => {
+      const value = [filterKey, filterValue.key];
+      const disabled = currentQueryState.filters.some(
+        (filter) => JSON.stringify(value) === JSON.stringify(filter)
+      );
+      return {
+        key: filterValue.key,
+        text: filterValue.label,
+        value: JSON.stringify(value),
+        disabled: disabled,
+      };
+    });
+
+    return (
+      <Dropdown
+        icon="filter"
+        labeled
+        item
+        button
+        trigger={
+          <span>
+            {filterLabel}
+            <Icon name='dropdown'/>
+          </span>
+        }
+        options={options}
+        onChange={this.onChangeFilter}
+        selectOnBlur={false}
+        value={null}
+        loading={loading}
+        className="icon fluid-responsive"
+        {...uiProps}
+      />
+    );
+  }
+}
+
+DropdownFilter.propTypes = {
+  updateQueryState: PropTypes.func.isRequired,
+  currentQueryState: PropTypes.object.isRequired,
+  filterKey: PropTypes.string.isRequired,
+  filterValues: PropTypes.array.isRequired,
+  filterLabel: PropTypes.string.isRequired,
+};
+
+DropdownFilter.defaultProps = {
+  filterLabel: "",
+};

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchFilters.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchFilters.js
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2022 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { DropdownFilter } from "@js/invenio_search_ui/components";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { withState } from "react-searchkit";
+
+export class SearchFiltersComponent extends Component {
+  render() {
+    const {
+      currentQueryState,
+      updateQueryState,
+      currentResultsState,
+      customFilters,
+    } = this.props;
+    const filters = customFilters
+      ? customFilters
+      : currentResultsState.data.aggregations;
+    return (
+      <>
+        {Object.entries(filters).map((filter) => (
+          <DropdownFilter
+            key={filter[0]}
+            filterKey={filter[0]}
+            filterLabel={filter[1].label}
+            filterValues={filter[1].buckets}
+            currentQueryState={currentQueryState}
+            updateQueryState={updateQueryState}
+            loading={currentResultsState.loading}
+            size="large"
+          />
+        ))}
+      </>
+    );
+  }
+}
+
+SearchFiltersComponent.propTypes = {
+  updateQueryState: PropTypes.func.isRequired,
+  currentQueryState: PropTypes.object.isRequired,
+  customFilters: PropTypes.object,
+};
+
+SearchFiltersComponent.defaultProps = {
+  customFilters: undefined,
+};
+
+export const SearchFilters = withState(SearchFiltersComponent);

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/index.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/index.js
@@ -10,10 +10,14 @@ export { ResultsGridItem } from "./ResultsGridItem";
 export { ResultsListItem } from "./ResultsListItem";
 export { Results } from "./Results";
 export { SearchBar } from "./SearchBar";
-export { SearchApp, SearchAppFacets, SearchAppResultsPane } from "./SearchApp";
+export { SearchApp } from "./SearchApp";
 export { SearchConfigurationContext } from "./context";
 export { InvenioSearchPagination } from "./InvenioSearchPagination";
 export {
   MultipleOptionsSearchBar,
   MultipleOptionsSearchBarRSK,
 } from "./MultipleOptionsSearchBar";
+export { SearchAppFacets } from "./SearchAppFacets";
+export { SearchAppResultsPane } from "./SearchAppResultsPane";
+export { DropdownSort, DropdownFilter } from "./SearchDropdowns";
+export { SearchFilters } from "./SearchFilters";


### PR DESCRIPTION
Will now reduce search app grid columns to 1 and hide the facets column to prevent it from taking up space if there are no facets.


partly closes https://github.com/inveniosoftware/invenio-administration/issues/6

no facets:
![Screenshot from 2022-08-15 11-10-46](https://user-images.githubusercontent.com/55200060/184608621-d0bb7591-d445-4fbc-8eef-d432a6186b09.png)
![Screenshot from 2022-08-15 11-10-59](https://user-images.githubusercontent.com/55200060/184608618-19cc7b54-0770-4999-af96-db9cc0f37963.png)

facets (should be the same):
![Screenshot from 2022-08-15 11-10-22](https://user-images.githubusercontent.com/55200060/184608628-cb3c7fd4-8efa-4675-ab34-7d0f4dab139b.png)
![Screenshot from 2022-08-15 11-12-44](https://user-images.githubusercontent.com/55200060/184608842-e52c8dd1-c618-4f80-a93e-3ba612d32181.png)
![Screenshot from 2022-08-15 11-10-35](https://user-images.githubusercontent.com/55200060/184608624-e4dec121-3794-47a9-8865-6f48b0cd1761.png)





