### PR TITLE
MultipleOptionsSearchBar: add aria-label

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/MultipleOptionsSearchBar.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/MultipleOptionsSearchBar.js
@@ -63,6 +63,7 @@ export class MultipleOptionsSearchBar extends Component {
         icon
         className="right-floated search"
         onClick={this.handleOnSearchClick}
+        aria-label={i18next.t("Search")}
       >
         <Icon name="search" />
       </Button>
@@ -132,6 +133,7 @@ export class MultipleOptionsSearchBarCmp extends Component {
         icon
         className="right-floated search"
         onClick={this.onBtnSearchClick}
+        aria-label={i18next.t("Search")}
       >
         <Icon name="search" />
       </Button>


### PR DESCRIPTION
multipleOptionsSearchBar: add aria-label

### Description

This PR endeavors to add an Aria label (with default value of "Search") to the search button, wherever MultipleOptionsSearchBar appears.

### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

Closes https://github.com/inveniosoftware/invenio-search-ui/issues/155