### PR TITLE
migrate: flask_babelex replaced by invenio_i18n

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 2.4.0 (released 2023-03-02)
+
+- remove deprecated flask-babelex dependency and imports
+
 Version 2.3.0 (released 2023-01-26)
 
 - assets: normalize overridable ids

--- a/invenio_search_ui/__init__.py
+++ b/invenio_search_ui/__init__.py
@@ -327,6 +327,6 @@ of the record in a list by using the ``ng-repeat`` attribute and the
 
 from .ext import InvenioSearchUI
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 __all__ = ("__version__", "InvenioSearchUI")

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     Babel>=2.8
     invenio-assets>=2.0.0
     invenio-base>=1.2.11
-    invenio-i18n>=1.3.2
+    invenio-i18n>=2.0.0,<3.0.0
 
 [options.extras_require]
 tests =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -15,8 +16,8 @@ import tempfile
 import jinja2
 import pytest
 from flask import Flask
-from flask_babelex import Babel
 from invenio_assets import InvenioAssets
+from invenio_i18n import Babel
 
 from invenio_search_ui import InvenioSearchUI
 from invenio_search_ui.views import blueprint


### PR DESCRIPTION
- NOTE invenio-i18n, invenio-records have to be released first