### PR TITLE
search config: add default_max_results

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/InvenioSearchPagination.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/InvenioSearchPagination.js
@@ -9,6 +9,7 @@ import { Pagination, ResultsPerPage } from "react-searchkit";
 import { Grid } from "semantic-ui-react";
 
 export const InvenioSearchPagination = ({ paginationOptions }) => {
+  const { maxTotalResults, resultsPerPage } = paginationOptions;
   return (
     <Grid.Row verticalAlign="middle">
       <Grid.Column className="computer tablet only" width={4}></Grid.Column>
@@ -22,6 +23,7 @@ export const InvenioSearchPagination = ({ paginationOptions }) => {
             size: "mini",
             showFirst: false,
             showLast: false,
+            maxTotalResults,
           }}
         />
       </Grid.Column>
@@ -31,6 +33,7 @@ export const InvenioSearchPagination = ({ paginationOptions }) => {
             boundaryRangeCount: 0,
             showFirst: false,
             showLast: false,
+            maxTotalResults,
           }}
         />
       </Grid.Column>
@@ -40,13 +43,13 @@ export const InvenioSearchPagination = ({ paginationOptions }) => {
         width={4}
       >
         <ResultsPerPage
-          values={paginationOptions.resultsPerPage}
+          values={resultsPerPage}
           label={(cmp) => <> {cmp} results per page</>}
         />
       </Grid.Column>
       <Grid.Column className="mobile only mt-10" textAlign="center" width={16}>
         <ResultsPerPage
-          values={paginationOptions.resultsPerPage}
+          values={resultsPerPage}
           label={(cmp) => <> {cmp} results per page</>}
         />
       </Grid.Column>

--- a/invenio_search_ui/searchconfig.py
+++ b/invenio_search_ui/searchconfig.py
@@ -85,6 +85,7 @@ class SearchAppConfig:
         pagination_options=(10, 20, 50),
         default_size=10,
         default_page=1,
+        default_max_results=10000,
         facets=None,
         sort=None,
         initial_filters=[],
@@ -106,6 +107,7 @@ class SearchAppConfig:
         :param default_size: An integer setting the default number of results
             per page.
         :param default_page: An integer setting the default page.
+        :param default_max_results: An integer setting the default maximum total results.
         """
         options = deepcopy(self.default_options)
         options.update(configuration_options)
@@ -183,6 +185,7 @@ class SearchAppConfig:
                 for option in self.pagination_options
             ],
             "defaultValue": self.default_size,
+            "maxTotalResults": self.default_max_results,
         }
 
     @property


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/217

Adds `default_max_results` to pagination options in backend, and passes to `<Pagination/>` component.