### PR TITLE
search dropdown: add flex to button content

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchDropdowns.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchDropdowns.js
@@ -60,7 +60,7 @@ export class DropdownSort extends Component {
         labeled
         item
         trigger={
-          <span>
+          <span className="flex align-items-center">
             {this.getCurrentlySelectedOption(parsedOptions).text}
             <Icon name="dropdown" />
           </span>
@@ -72,7 +72,7 @@ export class DropdownSort extends Component {
         selectOnNavigation={selectOnNavigation}
         selectOnBlur={false}
         size="large"
-        className="icon fluid-responsive"
+        className="icon fluid-mobile"
       />
     );
   }
@@ -124,7 +124,7 @@ export class DropdownFilter extends Component {
         item
         button
         trigger={
-          <span>
+          <span className="flex align-items-center">
             {filterLabel}
             <Icon name="dropdown" />
           </span>
@@ -134,7 +134,7 @@ export class DropdownFilter extends Component {
         selectOnBlur={false}
         value={null}
         loading={loading}
-        className="icon fluid-responsive"
+        className="icon fluid-mobile"
         {...uiProps}
       />
     );


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-communities/issues/983

Forces the text and dropdown icon to align by flex, as the text and the icon would stack vertically if the buttons got too squished. Also added `.fluid-mobile` instead of `.fluid-responive` because of the updated layout (see PR https://github.com/inveniosoftware/invenio-communities/pull/990)
<img width="451" alt="Screenshot 2023-07-31 at 17 08 19" src="https://github.com/inveniosoftware/invenio-search-ui/assets/21052053/b6b706d2-28f8-4021-b4d3-c9cd9aa9599e">
