### PR TITLE
facets: convert number to locale, a11y improvements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,7 +322,8 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
-
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/", None),
+}
 # Autodoc configuraton.
 autoclass_content = "both"

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/InvenioSearchPagination.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/InvenioSearchPagination.js
@@ -18,7 +18,7 @@ export const InvenioSearchPagination = ({ paginationOptions, total }) => {
         {total && <Count
           label={() => (
             <Trans>
-              <b>{{ total }}</b> results found
+              <b>{total.toLocaleString("en-US")}</b> results found
             </Trans>
           )}
         />}
@@ -66,7 +66,7 @@ export const InvenioSearchPagination = ({ paginationOptions, total }) => {
           label={() => (
             <span className="rel-mr-2">
               <Trans>
-                <b>{{ total }}</b> results found
+                <b>{total.toLocaleString("en-US")}</b> results found
               </Trans>
             </span>
           )}

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
@@ -133,6 +133,7 @@ export const SearchApp = ({ config, appName }) => {
                 <Grid.Row columns={columnsAmount}>
                   {facetsAvailable && (
                     <GridResponsiveSidebarColumn
+                      ariaLabel={i18next.t("Search filters")}
                       mobile={4}
                       tablet={4}
                       computer={4}
@@ -145,7 +146,11 @@ export const SearchApp = ({ config, appName }) => {
                     </GridResponsiveSidebarColumn>
                   )}
 
-                  <Grid.Column {...resultsPaneLayout}>
+                  <Grid.Column
+                    as="section"
+                    aria-label={i18next.t("Search results")}
+                    {...resultsPaneLayout}
+                  >
                     <SearchAppResultsPane
                       layoutOptions={config.layoutOptions} appName={appName} buildUID={buildUID}
                     />

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/common/facets.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/common/facets.js
@@ -20,7 +20,7 @@ import { BucketAggregation, Toggle, buildUID } from "react-searchkit";
 
 export const ContribSearchAppFacets = ({ aggs, toggle, help, appName }) => {
   return (
-    <aside aria-label={i18next.t("filters")} id="search-filters">
+    <>
       {toggle && (
         <Toggle
           title={i18next.t("Versions")}
@@ -44,7 +44,7 @@ export const ContribSearchAppFacets = ({ aggs, toggle, help, appName }) => {
           </Card.Content>
         </Card>
       )}
-    </aside>
+    </>
   );
 };
 
@@ -104,6 +104,7 @@ export const ContribParentFacetValue = ({
             icon="angle right"
             className="transparent"
             onClick={() => setIsActive(!isActive)}
+            aria-expanded={isActive}
             aria-label={
               i18next.t("Show all sub facets of ") + bucket.label || keyField
             }
@@ -111,13 +112,17 @@ export const ContribParentFacetValue = ({
           <Checkbox
             label={bucket.label || keyField}
             id={`${keyField}-facet-checkbox`}
-            aria-describedby={`${keyField}-count`}
             value={keyField}
             checked={isSelected}
             onClick={() => onFilterClicked(keyField)}
           />
-          <Label circular id={`${keyField}-count`} className="facet-count">
-            {bucket.doc_count}
+          <Label
+            circular
+            role="note"
+            aria-label={`${bucket.doc_count} results for ${bucket.label || keyField}`}
+            className="facet-count"
+          >
+            {bucket.doc_count.toLocaleString("en-US")}
           </Label>
         </List.Content>
       </Accordion.Title>
@@ -146,12 +151,16 @@ export const ContribFacetValue = ({
         onClick={() => onFilterClicked(keyField)}
         label={bucket.label || keyField}
         id={`${keyField}-facet-checkbox`}
-        aria-describedby={`${keyField}-count`}
         value={keyField}
         checked={isSelected}
       />
-      <Label circular id={`${keyField}-count`} className="facet-count">
-        {bucket.doc_count}
+      <Label
+        circular
+        role="note"
+        aria-label={`${bucket.doc_count} results for ${bucket.label || keyField}`}
+        className="facet-count"
+      >
+        {bucket.doc_count.toLocaleString("en-US")}
       </Label>
     </List.Content>
   );


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-search-ui/issues/182, closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2256, closes https://github.com/inveniosoftware/invenio-search-ui/issues/181

- Converts all result-numbers to locale
- Sets the aria-label to the responsive sidebar (needs https://github.com/inveniosoftware/react-invenio-forms/pull/208)
- Modifies the elements within the sidebar according to the PR mentioned above
- Improves screen reader navigation by adding `section` to the search results wrapper element
- Better a11y for count-labels

<img width="350" alt="Screenshot 2023-09-12 at 14 36 55" src="https://github.com/inveniosoftware/invenio-search-ui/assets/21052053/de34c0aa-de3a-4aa1-9f0f-5ce183bb8b34">
<img width="991" alt="Screenshot 2023-09-12 at 16 46 37" src="https://github.com/inveniosoftware/invenio-search-ui/assets/21052053/22391dac-fc31-40b6-a1ae-a477ff6f794e">


