### PR TITLE
a11y: allow users to tab across the search button (and release: v2.8.6)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 2.8.6
+
+- a11y: allow users to tab across the search button
+
 Version 2.8.5 (released 2024-03-04)
 
 - relax major upper pin of invenio-assets, as v3 only upgrades webpack to

--- a/invenio_search_ui/__init__.py
+++ b/invenio_search_ui/__init__.py
@@ -327,6 +327,6 @@ of the record in a list by using the ``ng-repeat`` attribute and the
 
 from .ext import InvenioSearchUI
 
-__version__ = "2.8.5"
+__version__ = "2.8.6"
 
 __all__ = ("__version__", "InvenioSearchUI")

--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/MultipleOptionsSearchBar.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/MultipleOptionsSearchBar.js
@@ -55,11 +55,6 @@ export class MultipleOptionsSearchBar extends Component {
     this.setState({ queryString: value });
   };
 
-  handleFocus = (e) => {
-    e.persist();
-    if(e.target.nodeName === "BUTTON") this.handleOnSearchClick();
-  }
-
   render() {
     const { placeholder, options } = this.props;
     const { queryString } = this.state;
@@ -67,6 +62,7 @@ export class MultipleOptionsSearchBar extends Component {
       <Button
         icon
         className="right-floated search"
+        onMouseDown={this.handleOnSearchClick} // not onClick as button moves after focus
         onClick={this.handleOnSearchClick}
         aria-label={i18next.t("Search")}
       >
@@ -80,7 +76,6 @@ export class MultipleOptionsSearchBar extends Component {
         onResultSelect={this.handleOnResultSelect}
         onSearchChange={this.handleOnSearchChange}
         resultRenderer={(props) => resultRenderer(props, queryString)}
-        onFocus={this.handleFocus}
         results={options}
         value={queryString}
         placeholder={placeholder}
@@ -133,17 +128,13 @@ export class MultipleOptionsSearchBarCmp extends Component {
     onInputChange(value);
   };
 
-  handleFocus = (e) => {
-    e.persist();
-    if(e.target.nodeName === "BUTTON") this.onBtnSearchClick();
-  }
-
   render() {
     const { placeholder, queryString, options } = this.props;
     const button = (
       <Button
         icon
         className="right-floated search"
+        onMouseDown={this.handleOnSearchClick} // not onClick as button moves after focus
         onClick={this.onBtnSearchClick}
         aria-label={i18next.t("Search")}
       >
@@ -158,7 +149,6 @@ export class MultipleOptionsSearchBarCmp extends Component {
         onResultSelect={this.onBtnSearchClick}
         onSearchChange={this.handleOnSearchChange}
         resultRenderer={(props) => resultRenderer(props, queryString)}
-        onFocus={this.handleFocus}
         results={options}
         value={queryString}
         placeholder={placeholder}


### PR DESCRIPTION
:heart: Thank you for your contribution!

Close #198

### Description

> Please describe briefly your pull request.

Fix https://github.com/zenodo/rdm-project/issues/634

Previously as soon as you select the search button via tab it would execute the search. Now we only look for onMouseDown.

We cannot use onClick because the button moves as soon as it is focused via mouse down.

The behaviour is now:

* The button will search with a single `click`
* The button will search with `enter` or `spacebar`
* The input will search if the user presses `enter`
#### Video:

https://github.com/inveniosoftware/invenio-search-ui/assets/6676843/961dbcdb-8585-412f-8937-79d6ed9db0c4

> Description: I tab across the interface and use shift tab to go back to the search box. I then select the search button and press enter to search


https://github.com/inveniosoftware/invenio-search-ui/assets/6676843/66fa8b52-4a2b-4066-aa80-1e432fb1c6ff

> Description: Single clicking on the button and single clicking on the expanded search button both result in navigating to the search results

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
