### PR TITLE
search results: render Mathjax in the results list and grid

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/Results.js
@@ -28,6 +28,10 @@ export const Results = ({ currentResultsState = {} }) => {
   const { sortOptions, layoutOptions, paginationOptions, buildUID } =
     useContext(SearchConfigurationContext);
   const multipleLayouts = layoutOptions.listView && layoutOptions.gridView;
+
+  const handleResultsRendered = () => {
+    window.invenio?.onSearchResultsRendered();
+  };
   return (
     (total || null) && (
       <Overridable
@@ -43,11 +47,11 @@ export const Results = ({ currentResultsState = {} }) => {
           <Grid.Row>
             <Grid.Column>
               {multipleLayouts ? (
-                <ResultsMultiLayout />
+                <ResultsMultiLayout onResultsRendered={handleResultsRendered}/>
               ) : layoutOptions.listView ? (
-                <ResultsList />
+                <ResultsList onResultsRendered={handleResultsRendered}/>
               ) : (
-                <ResultsGrid />
+                <ResultsGrid onResultsRendered={handleResultsRendered}/>
               )}
             </Grid.Column>
           </Grid.Row>


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/198

Please note that in case the formula doesn't fit into description completely, it doesn't get printed correctly (2d record on the screenshot)

<img width="1368" alt="Screenshot 2024-09-19 at 17 01 51" src="https://github.com/user-attachments/assets/25b02a1e-3ae7-4e15-ba5a-9849d7bcd975">
<img width="1284" alt="Screenshot 2024-09-19 at 17 02 03" src="https://github.com/user-attachments/assets/5558265e-22c4-4a58-8f5e-d51c1472f6dd">
<img width="1355" alt="Screenshot 2024-09-19 at 17 02 50" src="https://github.com/user-attachments/assets/295bdf51-bad4-47f8-aeb1-7ff76e0660b3">

