### PR TITLE
overridable: pass config to searchbarContainer

### DIFF
--- a/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
+++ b/invenio_search_ui/assets/semantic-ui/js/invenio_search_ui/components/SearchApp.js
@@ -104,7 +104,7 @@ export const SearchApp = ({ config, appName }) => {
                 <Grid.Row
                   textAlign="right"
                   columns={columnsAmount}
-                  className="result-options rel-mt-2"
+                  className="result-options"
                 >
                   {facetsAvailable && (
                     <Grid.Column


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

SearchBar expects config to be passed, but if you just override "SearchApp.searchbarContainer" it previously did not get passed the config

Second commit reverts https://github.com/inveniosoftware/invenio-search-ui/pull/132 which I received approval from karolina for
